### PR TITLE
Fix dependency issues with our other gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.gem
 .bundle
 .yardoc
-coverage
 Gemfile.lock
 doc/*
 pkg/*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/turbotlib.svg)](https://badge.fury.io/rb/turbotlib)
 [![Build Status](https://secure.travis-ci.org/openc/turbotlib-ruby.png)](https://travis-ci.org/openc/turbotlib-ruby)
 [![Dependency Status](https://gemnasium.com/openc/turbotlib-ruby.png)](https://gemnasium.com/openc/turbotlib-ruby)
-[![Coverage Status](https://coveralls.io/repos/openc/turbotlib-ruby/badge.png)](https://coveralls.io/r/openc/turbotlib-ruby)
 [![Code Climate](https://codeclimate.com/github/openc/turbotlib-ruby.png)](https://codeclimate.com/github/openc/turbotlib-ruby)
 
 ## Releasing a new version

--- a/lib/turbotlib/version.rb
+++ b/lib/turbotlib/version.rb
@@ -1,3 +1,3 @@
 module TurbotLib
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,5 @@
 require 'rubygems'
 
-require "simplecov"
-require "coveralls"
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-  add_filter "spec"
-end
-
 require 'rspec'
 require 'webmock/rspec'
 

--- a/turbotlib.gemspec
+++ b/turbotlib.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "scraperwiki", "~> 3.0.2"
   gem.add_runtime_dependency "faraday", "~> 0.9.0"
-  gem.add_runtime_dependency "retriable", "~> 2.0.2"
+  gem.add_runtime_dependency "retriable", "~> 2.1"
 
   gem.add_development_dependency "activesupport", "~> 4.1.0"
   gem.add_development_dependency "faraday_middleware"

--- a/turbotlib.gemspec
+++ b/turbotlib.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "retriable", "~> 2.0.2"
 
   gem.add_development_dependency "activesupport", "~> 4.1.0"
-  gem.add_development_dependency "coveralls"
   gem.add_development_dependency "faraday_middleware"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.4"

--- a/turbotlib.gemspec
+++ b/turbotlib.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday_middleware"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.4"
-  gem.add_development_dependency "webmock"
+  gem.add_development_dependency "webmock", "~> 2.2.0"
 end


### PR DESCRIPTION
This is to get `openc_bot`, `turbot-ruby-gems` and `turbotlib-ruby` to share the same versions of certain dependencies.